### PR TITLE
OpenClaw と汎用クライアント向けの独立 WebSocket ゲートウェイを追加 (2コンテナ構成)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# OpenAI Codex App Server WebSocket Gateway (2コンテナ構成)
+
+このリポジトリは、OpenAI Codex App Server へ接続するための WebSocket クライアント機能を
+Docker コンテナとして提供します。
+
+- `gateway-openclaw`: openclaw 専用
+- `gateway-general`: 自作 AI アプリ / Claude など汎用
+
+## 主な機能
+
+- WebSocket プロキシ (`/ws`)。
+- サブスク認証向けの 2 ステップフロー。
+  1. コンテナから認証 URL を取得 (`GET /auth/url`)
+  2. ブラウザから戻ってきた URL をコンテナへ投入 (`POST /auth/callback`)
+- 最低限のセキュリティ
+  - Bearer API キー必須
+  - Origin 許可リスト
+  - コールバック URL ドメイン許可リスト
+  - 機密を永続化しない (デフォルト in-memory)
+
+## 起動
+
+```bash
+docker compose up --build
+```
+
+## 環境変数
+
+- `GATEWAY_API_KEYS`: カンマ区切り API キー。
+- `ALLOWED_ORIGINS`: 許可 Origin。
+- `ALLOWED_CALLBACK_HOSTS`: 認証後 URL の許可ホスト。
+- `OPENAI_APP_SERVER_WS_URL`: 接続先 WebSocket URL。
+- `AUTH_START_URL_TEMPLATE`: 認証 URL テンプレート。`{state}` を含める。
+
+## API
+
+### `GET /auth/url`
+
+ヘッダ: `Authorization: Bearer <key>`
+
+state を払い出し、ユーザーがブラウザで開く認証 URL を返却します。
+
+### `POST /auth/callback`
+
+ヘッダ: `Authorization: Bearer <key>`
+
+```json
+{
+  "return_url": "https://example.com/callback?code=...&state=..."
+}
+```
+
+state を検証し、URL をメモリに保存します。
+
+### `GET /auth/session/{state}`
+
+ヘッダ: `Authorization: Bearer <key>`
+
+保存された callback URL を取得します。
+
+### `GET /ws`
+
+ヘッダ: `Authorization: Bearer <key>`
+
+クエリ:
+- `target`: 任意で WebSocket 接続先を上書き
+
+クライアントと上流 WebSocket を双方向中継します。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  gateway-openclaw:
+    build: ./gateway
+    container_name: gateway-openclaw
+    environment:
+      GATEWAY_API_KEYS: "openclaw-local-key"
+      ALLOWED_ORIGINS: "http://openclaw:3000"
+      ALLOWED_CALLBACK_HOSTS: "localhost,127.0.0.1"
+      OPENAI_APP_SERVER_WS_URL: "ws://host.docker.internal:9000/ws"
+      AUTH_START_URL_TEMPLATE: "https://example.com/openclaw/auth?state={state}"
+    ports:
+      - "18080:8080"
+
+  gateway-general:
+    build: ./gateway
+    container_name: gateway-general
+    environment:
+      GATEWAY_API_KEYS: "general-local-key"
+      ALLOWED_ORIGINS: "http://localhost,http://127.0.0.1"
+      ALLOWED_CALLBACK_HOSTS: "localhost,127.0.0.1"
+      OPENAI_APP_SERVER_WS_URL: "ws://host.docker.internal:9000/ws"
+      AUTH_START_URL_TEMPLATE: "https://example.com/general/auth?state={state}"
+    ports:
+      - "28080:8080"

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+EXPOSE 8080
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -1,0 +1,118 @@
+import asyncio
+import os
+import secrets
+import time
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel, HttpUrl
+import websockets
+
+app = FastAPI(title="codex-app-server-gateway")
+
+API_KEYS = {k.strip() for k in os.getenv("GATEWAY_API_KEYS", "dev-key").split(",") if k.strip()}
+ALLOWED_ORIGINS = {o.strip() for o in os.getenv("ALLOWED_ORIGINS", "http://localhost").split(",") if o.strip()}
+ALLOWED_CALLBACK_HOSTS = {h.strip() for h in os.getenv("ALLOWED_CALLBACK_HOSTS", "localhost").split(",") if h.strip()}
+DEFAULT_UPSTREAM_WS = os.getenv("OPENAI_APP_SERVER_WS_URL", "ws://host.docker.internal:9000/ws")
+AUTH_TEMPLATE = os.getenv("AUTH_START_URL_TEMPLATE", "https://example.com/auth?state={state}")
+STATE_TTL_SEC = int(os.getenv("STATE_TTL_SEC", "900"))
+
+state_store: Dict[str, float] = {}
+callback_store: Dict[str, str] = {}
+
+
+def _check_bearer(auth_header: Optional[str]) -> None:
+    if not auth_header or not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    token = auth_header.split(" ", 1)[1]
+    if token not in API_KEYS:
+        raise HTTPException(status_code=403, detail="invalid api key")
+
+
+def _cleanup_expired_states() -> None:
+    now = time.time()
+    expired = [s for s, ts in state_store.items() if now - ts > STATE_TTL_SEC]
+    for s in expired:
+        state_store.pop(s, None)
+        callback_store.pop(s, None)
+
+
+class CallbackPayload(BaseModel):
+    return_url: HttpUrl
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"ok": True}
+
+
+@app.get("/auth/url")
+async def auth_url(authorization: Optional[str] = Header(default=None)):
+    _check_bearer(authorization)
+    _cleanup_expired_states()
+    state = secrets.token_urlsafe(24)
+    state_store[state] = time.time()
+    return {"state": state, "auth_url": AUTH_TEMPLATE.format(state=state)}
+
+
+@app.post("/auth/callback")
+async def auth_callback(payload: CallbackPayload, authorization: Optional[str] = Header(default=None)):
+    _check_bearer(authorization)
+    _cleanup_expired_states()
+    parsed = urlparse(str(payload.return_url))
+    if parsed.hostname not in ALLOWED_CALLBACK_HOSTS:
+        raise HTTPException(status_code=400, detail="callback host not allowed")
+
+    state = parsed.query.split("state=")[-1].split("&")[0] if "state=" in parsed.query else ""
+    if not state or state not in state_store:
+        raise HTTPException(status_code=400, detail="invalid or expired state")
+
+    callback_store[state] = str(payload.return_url)
+    return {"stored": True, "state": state}
+
+
+@app.get("/auth/session/{state}")
+async def auth_session(state: str, authorization: Optional[str] = Header(default=None)):
+    _check_bearer(authorization)
+    _cleanup_expired_states()
+    if state not in callback_store:
+        raise HTTPException(status_code=404, detail="session not found")
+    return {"state": state, "return_url": callback_store[state]}
+
+
+@app.websocket("/ws")
+async def ws_proxy(ws: WebSocket):
+    auth = ws.headers.get("authorization")
+    origin = ws.headers.get("origin", "")
+
+    try:
+        _check_bearer(auth)
+    except HTTPException:
+        await ws.close(code=4401)
+        return
+
+    if origin and origin not in ALLOWED_ORIGINS:
+        await ws.close(code=4403)
+        return
+
+    target = ws.query_params.get("target") or DEFAULT_UPSTREAM_WS
+
+    await ws.accept()
+
+    try:
+        async with websockets.connect(target, max_size=2**20) as upstream:
+            async def client_to_upstream():
+                while True:
+                    msg = await ws.receive_text()
+                    await upstream.send(msg)
+
+            async def upstream_to_client():
+                async for msg in upstream:
+                    await ws.send_text(msg)
+
+            await asyncio.gather(client_to_upstream(), upstream_to_client())
+    except WebSocketDisconnect:
+        pass
+    except Exception:
+        await ws.close(code=1011)

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+websockets==15.0.1


### PR DESCRIPTION
### Motivation
- OpenAI Codex App Server へ接続するための WebSocket クライアント機能を、OpenClaw 専用と汎用向けに分離して安全に提供する目的で追加した。
- ブラウザ経由のサブスクリプション認証フローをコンテナ側で受け取り管理できるようにするための state / callback 保存機能を実装した。

### Description
- `gateway/app.py` に FastAPI ベースの WebSocket ゲートウェイを追加し、`/ws` 双方向プロキシと認証用エンドポイント `GET /auth/url`、`POST /auth/callback`、`GET /auth/session/{state}` を実装した。 
- セキュリティ対策として Bearer API キー検証、Origin 許可リスト、コールバックホスト許可リスト、`state` の TTL 管理、および機密を永続化しないインメモリ保存を導入した。 
- コンテナ化のために `gateway/Dockerfile` と依存の `gateway/requirements.txt` を追加し、複数構成を管理する `docker-compose.yml` に `gateway-openclaw` と `gateway-general` の2サービスを定義した。 
- 利用方法と API を `README.md` に記載し、環境変数（`GATEWAY_API_KEYS`、`ALLOWED_ORIGINS`、`ALLOWED_CALLBACK_HOSTS`、`OPENAI_APP_SERVER_WS_URL`、`AUTH_START_URL_TEMPLATE` など）で挙動を制御可能とした。 

### Testing
- `python3 -m py_compile gateway/app.py` を実行し、Python 構文チェックは成功した。 
- `docker compose config` による構成検証はこの実行環境に `docker` コマンドがないため実行できなかった（検証不可）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7f310c2508332b44cc6414043bb78)